### PR TITLE
Feature: Support for community provider like Ollama

### DIFF
--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -15,21 +15,18 @@ export const coreProviders: Record<string, ProviderV1> = {
  * A list of all provider implementations available via the Vercel AI SDK.  
  * Includes built-in providers such as OpenAI, Anthropic, Azure, Cohere, and community provider like Ollama.  
  */
-export const supportedProviders: { name: string, packagePath: string; exportName: string }[] = [
+export const supportedProviders: { name: string, packagePath: string; exportName?: string }[] = [
   {
     name: 'openai',
-    packagePath: '@ai-sdk/openai',
-    exportName: 'openai'
+    packagePath: '@ai-sdk/openai'
   },
   {
     name: 'azure',
-    packagePath: '@ai-sdk/azure',
-    exportName: 'azure'
+    packagePath: '@ai-sdk/azure'
   },
   {
     name: 'anthropic',
-    packagePath: '@ai-sdk/anthropic',
-    exportName: 'anthropic'
+    packagePath: '@ai-sdk/anthropic'
   },
   {
     name: 'amazon-bedrock',
@@ -38,8 +35,7 @@ export const supportedProviders: { name: string, packagePath: string; exportName
   },
   {
     name: 'google',
-    packagePath: '@ai-sdk/google',
-    exportName: 'google'
+    packagePath: '@ai-sdk/google'
   },
   {
     name: 'google-vertex',
@@ -48,68 +44,55 @@ export const supportedProviders: { name: string, packagePath: string; exportName
   },
   {
     name: 'mistral',
-    packagePath: '@ai-sdk/mistral',
-    exportName: 'mistral'
+    packagePath: '@ai-sdk/mistral'
   },
   {
     name: 'xai',
-    packagePath: '@ai-sdk/xai',
-    exportName: 'xai'
+    packagePath: '@ai-sdk/xai'
   },
   {
     name: 'togetherai',
-    packagePath: '@ai-sdk/togetherai',
-    exportName: 'togetherai'
+    packagePath: '@ai-sdk/togetherai'
   },
   {
     name: 'cohere',
-    packagePath: '@ai-sdk/cohere',
-    exportName: 'cohere'
+    packagePath: '@ai-sdk/cohere'
   },
   {
     name: 'fireworks',
-    packagePath: '@ai-sdk/fireworks',
-    exportName: 'fireworks'
+    packagePath: '@ai-sdk/fireworks'
   },
   {
     name: 'deepinfra',
-    packagePath: '@ai-sdk/deepinfra',
-    exportName: 'deepinfra'
+    packagePath: '@ai-sdk/deepinfra'
   },
   {
     name: 'deepseek',
-    packagePath: '@ai-sdk/deepseek',
-    exportName: 'deepseek'
+    packagePath: '@ai-sdk/deepseek'
   },
   {
     name: 'cerebras',
-    packagePath: '@ai-sdk/cerebras',
-    exportName: 'cerebras'
+    packagePath: '@ai-sdk/cerebras'
   },
   {
     name: 'groq',
-    packagePath: '@ai-sdk/groq',
-    exportName: 'groq'
+    packagePath: '@ai-sdk/groq'
   },
   {
     name: 'perplexity',
-    packagePath: '@ai-sdk/perplexity',
-    exportName: 'perplexity'
+    packagePath: '@ai-sdk/perplexity'
   },
   {
     name: 'luma',
-    packagePath: '@ai-sdk/luma',
-    exportName: 'luma'
+    packagePath: '@ai-sdk/luma'
   },
   {
     name: 'fal',
-    packagePath: '@ai-sdk/fal',
-    exportName: 'fal'
+    packagePath: '@ai-sdk/fal'
   },
   {
     name: 'ollama',
-    packagePath: 'ollama-ai-provider',
-    exportName: 'ollama'
+    packagePath: 'ollama-ai-provider'
   }
 ]
 
@@ -148,14 +131,14 @@ export async function loadDynamicProvider(
         `Unsupported provider '${providerName}'. Refer to the list of supported providers here: https://axar-ai.gitbook.io/axar/basics/model.`
       );
     }
-
     const modulePath = require.resolve(selectedProvider.packagePath, { paths: [process.cwd()] });
     const providerModule = await import(modulePath);
-    const provider = providerModule[selectedProvider.exportName];
+    const exportName = selectedProvider?.exportName ?? selectedProvider?.name;
+    const provider = providerModule[exportName];
 
     if (!isValidProvider(provider)) {
       throw new Error(
-        `The export "${selectedProvider.exportName}" does not implement the ProviderV1 interface in the module "${selectedProvider.packagePath}".`,
+        `The export "${exportName}" does not implement the ProviderV1 interface in the module "${selectedProvider.packagePath}".`,
       );
     }
 

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -125,7 +125,6 @@ function isValidProvider(provider: unknown): provider is ProviderV1 {
  * @returns True if the error is a module not found error.
  */
 function isModuleNotFoundError(error: unknown): error is NodeJS.ErrnoException {
-  console.log("🚀 ~ isModuleNotFoundError ~ error:", error)
   return (
     typeof error === 'object' &&
     error !== null &&

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -15,7 +15,7 @@ export const coreProviders: Record<string, ProviderV1> = {
  * A list of all provider implementations available via the Vercel AI SDK.  
  * Includes built-in providers such as OpenAI, Anthropic, Azure, Cohere, and community provider like Ollama.  
  */
-const SupportedProviders: { name: string, packagePath: string; exportName: string }[] = [
+export const supportedProviders: { name: string, packagePath: string; exportName: string }[] = [
   {
     name: 'openai',
     packagePath: '@ai-sdk/openai',
@@ -71,7 +71,7 @@ export async function loadDynamicProvider(
     return dynamicProviderCache[providerName];
   }
 
-  const selectedProvider = SupportedProviders.find(provider => provider.name === providerName);
+  const selectedProvider = supportedProviders.find(provider => provider.name === providerName);
   try {
     if (!selectedProvider) {
       throw new Error(
@@ -79,7 +79,8 @@ export async function loadDynamicProvider(
       );
     }
 
-    const providerModule = await import(selectedProvider.packagePath);
+    const modulePath = require.resolve(selectedProvider.packagePath, { paths: [process.cwd()] });
+    const providerModule = await import(modulePath);
     const provider = providerModule[selectedProvider.exportName];
 
     if (!isValidProvider(provider)) {
@@ -124,6 +125,7 @@ function isValidProvider(provider: unknown): provider is ProviderV1 {
  * @returns True if the error is a module not found error.
  */
 function isModuleNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+  console.log("🚀 ~ isModuleNotFoundError ~ error:", error)
   return (
     typeof error === 'object' &&
     error !== null &&

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -85,7 +85,7 @@ export async function loadDynamicProvider(
 
     if (!isValidProvider(provider)) {
       throw new Error(
-        `The export "${providerName}" does not implement the ProviderV1 interface in the module "${selectedProvider.packagePath}".`,
+        `The export "${selectedProvider.exportName}" does not implement the ProviderV1 interface in the module "${selectedProvider.packagePath}".`,
       );
     }
 

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -15,31 +15,26 @@ export const coreProviders: Record<string, ProviderV1> = {
  * A list of all provider implementations available via the Vercel AI SDK.  
  * Includes built-in providers such as OpenAI, Anthropic, Azure, Cohere, and community provider like Ollama.  
  */
-export const supportedProviders: { name: string, packagePath: string; exportName: string }[] = [
+export const supportedProviders: { name: string, packagePath: string; }[] = [
   {
     name: 'openai',
-    packagePath: '@ai-sdk/openai',
-    exportName: 'openai'
+    packagePath: '@ai-sdk/openai'
   },
   {
     name: 'azure',
-    packagePath: '@ai-sdk/azure',
-    exportName: 'azure'
+    packagePath: '@ai-sdk/azure'
   },
   {
     name: 'anthropic',
-    packagePath: '@ai-sdk/anthropic',
-    exportName: 'anthropic'
+    packagePath: '@ai-sdk/anthropic'
   },
   {
     name: 'cohere',
-    packagePath: '@ai-sdk/cohere',
-    exportName: 'cohere'
+    packagePath: '@ai-sdk/cohere'
   },
   {
     name: 'ollama',
-    packagePath: 'ollama-ai-provider',
-    exportName: 'ollama'
+    packagePath: 'ollama-ai-provider'
   }
 ]
 
@@ -81,11 +76,11 @@ export async function loadDynamicProvider(
 
     const modulePath = require.resolve(selectedProvider.packagePath, { paths: [process.cwd()] });
     const providerModule = await import(modulePath);
-    const provider = providerModule[selectedProvider.exportName];
+    const provider = providerModule[selectedProvider.name];
 
     if (!isValidProvider(provider)) {
       throw new Error(
-        `The export "${selectedProvider.exportName}" does not implement the ProviderV1 interface in the module "${selectedProvider.packagePath}".`,
+        `The export "${selectedProvider.name}" does not implement the ProviderV1 interface in the module "${selectedProvider.packagePath}".`,
       );
     }
 
@@ -110,7 +105,7 @@ export async function loadDynamicProvider(
  * @param provider The object to validate.
  * @returns True if the object implements ProviderV1.
  */
-function isValidProvider(provider: unknown): provider is ProviderV1 {
+export function isValidProvider(provider: unknown): provider is ProviderV1 {
   return (
     (typeof provider === 'object' || typeof provider === 'function') &&
     provider !== null &&

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -15,26 +15,101 @@ export const coreProviders: Record<string, ProviderV1> = {
  * A list of all provider implementations available via the Vercel AI SDK.  
  * Includes built-in providers such as OpenAI, Anthropic, Azure, Cohere, and community provider like Ollama.  
  */
-export const supportedProviders: { name: string, packagePath: string; }[] = [
+export const supportedProviders: { name: string, packagePath: string; exportName: string }[] = [
   {
     name: 'openai',
-    packagePath: '@ai-sdk/openai'
+    packagePath: '@ai-sdk/openai',
+    exportName: 'openai'
   },
   {
     name: 'azure',
-    packagePath: '@ai-sdk/azure'
+    packagePath: '@ai-sdk/azure',
+    exportName: 'azure'
   },
   {
     name: 'anthropic',
-    packagePath: '@ai-sdk/anthropic'
+    packagePath: '@ai-sdk/anthropic',
+    exportName: 'anthropic'
+  },
+  {
+    name: 'amazon-bedrock',
+    packagePath: '@ai-sdk/amazon-bedrock',
+    exportName: 'bedrock'
+  },
+  {
+    name: 'google',
+    packagePath: '@ai-sdk/google',
+    exportName: 'google'
+  },
+  {
+    name: 'google-vertex',
+    packagePath: '@ai-sdk/google-vertex',
+    exportName: 'vertex'
+  },
+  {
+    name: 'mistral',
+    packagePath: '@ai-sdk/mistral',
+    exportName: 'mistral'
+  },
+  {
+    name: 'xai',
+    packagePath: '@ai-sdk/xai',
+    exportName: 'xai'
+  },
+  {
+    name: 'togetherai',
+    packagePath: '@ai-sdk/togetherai',
+    exportName: 'togetherai'
   },
   {
     name: 'cohere',
-    packagePath: '@ai-sdk/cohere'
+    packagePath: '@ai-sdk/cohere',
+    exportName: 'cohere'
+  },
+  {
+    name: 'fireworks',
+    packagePath: '@ai-sdk/fireworks',
+    exportName: 'fireworks'
+  },
+  {
+    name: 'deepinfra',
+    packagePath: '@ai-sdk/deepinfra',
+    exportName: 'deepinfra'
+  },
+  {
+    name: 'deepseek',
+    packagePath: '@ai-sdk/deepseek',
+    exportName: 'deepseek'
+  },
+  {
+    name: 'cerebras',
+    packagePath: '@ai-sdk/cerebras',
+    exportName: 'cerebras'
+  },
+  {
+    name: 'groq',
+    packagePath: '@ai-sdk/groq',
+    exportName: 'groq'
+  },
+  {
+    name: 'perplexity',
+    packagePath: '@ai-sdk/perplexity',
+    exportName: 'perplexity'
+  },
+  {
+    name: 'luma',
+    packagePath: '@ai-sdk/luma',
+    exportName: 'luma'
+  },
+  {
+    name: 'fal',
+    packagePath: '@ai-sdk/fal',
+    exportName: 'fal'
   },
   {
     name: 'ollama',
-    packagePath: 'ollama-ai-provider'
+    packagePath: 'ollama-ai-provider',
+    exportName: 'ollama'
   }
 ]
 
@@ -76,11 +151,11 @@ export async function loadDynamicProvider(
 
     const modulePath = require.resolve(selectedProvider.packagePath, { paths: [process.cwd()] });
     const providerModule = await import(modulePath);
-    const provider = providerModule[selectedProvider.name];
+    const provider = providerModule[selectedProvider.exportName];
 
     if (!isValidProvider(provider)) {
       throw new Error(
-        `The export "${selectedProvider.name}" does not implement the ProviderV1 interface in the module "${selectedProvider.packagePath}".`,
+        `The export "${selectedProvider.exportName}" does not implement the ProviderV1 interface in the module "${selectedProvider.packagePath}".`,
       );
     }
 

--- a/test/unit/llm/providers.test.ts
+++ b/test/unit/llm/providers.test.ts
@@ -17,7 +17,7 @@ jest.mock(
 );
 
 jest.mock(
-  '@ai-sdk/invalid-provider',
+  '@ai-sdk/azure',
   () => ({
     'invalid-provider': {},
   }),
@@ -71,14 +71,16 @@ describe('providers.ts', () => {
     });
 
     it('should throw error for invalid provider implementation', async () => {
-      await expect(loadDynamicProvider('invalid-provider')).rejects.toThrow(
+      // The 'azure' provider was mocked at the top of the file as an empty object, 
+      // which does not conform to the ProviderV1 interface.
+      await expect(loadDynamicProvider('azure')).rejects.toThrow(
         'does not implement the ProviderV1 interface',
       );
     });
 
     it('should throw error for non-existent provider', async () => {
       await expect(loadDynamicProvider('non-existent')).rejects.toThrow(
-        'is not installed',
+        'Unsupported provider',
       );
     });
   });


### PR DESCRIPTION
This is a PR for the issue: https://github.com/axar-ai/axar/issues/34

**Changes:**
To maintain a simple interface for users, such as `@model('ollama:llama3.2')`, we need to track both the package name and the default exported object name. Fortunately, for built-in packages, all are in the format `@ai-sdk/<provider>`, and we can expect the <provider> object.

However, for community packages like `ollama-ai-provider`, they may have different exported objects.

A downside is that we will need to list all the provider names, even though this is defined on Vercel’s side.

**Output:**
![image](https://github.com/user-attachments/assets/1a7faf95-dd7b-420d-8bb9-fcc2086cc7fe)
