### PR TITLE
feat: add configurable @maxSteps decorator support

### DIFF
--- a/src/agent/decorators.ts
+++ b/src/agent/decorators.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { z, ZodSchema, ZodObject } from 'zod';
-import { META_KEYS } from './meta-keys';
+import { META_KEYS, MAX_STEPS } from './meta-keys';
 import { ToolMetadata, InputOutputType } from './types';
 import { hasSchemaDef, getSchemaDef } from '../schema';
 import { SchemaConstructor } from '../schema';
@@ -361,5 +361,16 @@ export function tool(
     };
 
     return descriptor;
+  };
+}
+
+/**
+ * Decorator to configure the maximum number of execution steps for an Agent.
+ *
+ * @param steps - The maximum number of steps allowed.
+ */
+export function maxSteps(steps: number): ClassDecorator {
+  return (target: Function) => {
+    Reflect.defineMetadata(MAX_STEPS, steps, target);
   };
 }

--- a/src/agent/meta-keys.ts
+++ b/src/agent/meta-keys.ts
@@ -7,4 +7,11 @@ export const META_KEYS = {
 } as const;
 
 // Add new meta key for maximum steps configuration
-export const MAX_STEPS = Symbol('maxSteps');
+export const META_KEYS = {
+  MODEL: Symbol('axar:model'),
+  SYSTEM_PROMPTS: Symbol('axar:systemPrompts'),
+  TOOLS: Symbol('axar:tools'),
+  OUTPUT: Symbol('axar:output'),
+  INPUT: Symbol('axar:input'),
+  MAX_STEPS: Symbol('axar:maxSteps'),
+} as const;

--- a/src/agent/meta-keys.ts
+++ b/src/agent/meta-keys.ts
@@ -5,3 +5,6 @@ export const META_KEYS = {
   OUTPUT: Symbol('axar:output'),
   INPUT: Symbol('axar:input'),
 } as const;
+
+// Add new meta key for maximum steps configuration
+export const MAX_STEPS = Symbol('maxSteps');

--- a/test/unit/agent/decorators.test.ts
+++ b/test/unit/agent/decorators.test.ts
@@ -344,8 +344,7 @@ describe('Decorators', () => {
   });
 
   describe('@maxSteps', () => {
-    const { Agent, tool, maxSteps } = require('../../../src/agent');
-    const { z } = require('zod');
+    const { Agent } = require('../../../src/agent');
 
     // Define a dummy agent class that extends Agent
     class TestAgent extends Agent<string, string> {


### PR DESCRIPTION
- Introduce a new meta key and @maxSteps decorator to allow users to set the maxSteps value via decorator instead of subclass override.
- Update the Agent class to first check for the @maxSteps metadata, falling back to the default (number of tools) if not provided.
- Add tests to verify the behavior of the @maxSteps functionality.