### PR TITLE
#37 : Fix broken link 'examples/bank-agent4.ts' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can easily extend AXAR agents with tools, dynamic prompts, and structured re
 
 Here's a more complex example (truncated to fit in this README):
 
-(Full code here: [examples/bank-agent4.ts](examples/bank-agent4.ts))
+- [Full code here](./examples/bank-agent/bank-agent-with-schema.ts)
 
 <p align="center">
   <img src="https://1845789600-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FEsqZ01bZEklboQR0Pa9C%2Fuploads%2F1w7BWzdiMjXduOh0KAzW%2Fbank-agent.svg?alt=media&token=dcc90aa0-3119-4ecd-9f03-991f7dc99a35">

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can easily extend AXAR agents with tools, dynamic prompts, and structured re
 
 Here's a more complex example (truncated to fit in this README):
 
-- [Full code here](./examples/bank-agent/bank-agent-with-schema.ts)
+[Full code here](./examples/bank-agent/bank-agent-with-schema.ts)
 
 <p align="center">
   <img src="https://1845789600-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FEsqZ01bZEklboQR0Pa9C%2Fuploads%2F1w7BWzdiMjXduOh0KAzW%2Fbank-agent.svg?alt=media&token=dcc90aa0-3119-4ecd-9f03-991f7dc99a35">


### PR DESCRIPTION
**Fixes #37 – Broken link in documentation:**

The link to examples/bank-agent4.ts in the documentation was broken, resulting in a 404 error when clicked. This PR updates the link to ensure that it correctly points to the full example file.

Changes:
- Fixed the broken link in the "Bank agent (dynamic prompts, tools, structured data, and DI)" section.
- Verified that the link now leads to the correct file.

This should resolve the issue and improve the documentation by providing accurate links to examples.

**Before fix:** 
<img width="652" alt="Screenshot 2025-01-31 060554" src="https://github.com/user-attachments/assets/e3d34ba9-09ea-4038-8119-51f4a8e141f4" />

**After fix:** 

<img width="623" alt="Screenshot 2025-01-31 060721" src="https://github.com/user-attachments/assets/f31daf36-da74-43c1-8d4c-17a4892c1467" />




