### PR TITLE
refactor(logger): make pino-pretty an optional peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axarai/axar",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axarai/axar",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.6",
@@ -33,12 +33,19 @@
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
         "open-cli": "^8.0.0",
-        "pino-pretty": "^13.0.0",
         "prettier": "^3.4.2",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.2"
+      },
+      "peerDependencies": {
+        "pino-pretty": "^13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "pino-pretty": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -3270,7 +3277,8 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3356,7 +3364,8 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -3524,7 +3533,8 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3647,7 +3657,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
       "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3667,7 +3678,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3926,7 +3938,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -4814,7 +4827,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5102,7 +5116,8 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5219,7 +5234,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5476,7 +5491,8 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.0.0.tgz",
       "integrity": "sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "colorette": "^2.0.7",
         "dateformat": "^4.6.3",
@@ -5658,7 +5674,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
       "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6053,7 +6070,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       },
@@ -6575,7 +6592,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -72,11 +72,18 @@
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "open-cli": "^8.0.0",
-    "pino-pretty": "^13.0.0",
     "prettier": "^3.4.2",
     "ts-jest": "^29.2.5",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.2",
     "ts-node": "^10.9.2"
+  },
+  "peerDependencies": {
+    "pino-pretty": "^13.0.0"
+  },
+  "peerDependenciesMeta": {
+    "pino-pretty": {
+      "optional": true
+    }
   }
 }

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -2,17 +2,27 @@ import pino from 'pino';
 
 const isNotProduction = process.env.NODE_ENV !== 'production';
 
+// Check if pino-pretty is available
+const getPrettyTransport = () => {
+  if (!isNotProduction) return undefined;
+
+  try {
+    require.resolve('pino-pretty');
+    return {
+      target: 'pino-pretty',
+      options: {
+        colorize: true,
+      },
+    };
+  } catch (e) {
+    // Silently fallback to default transport if pino-pretty is not available
+    return undefined;
+  }
+};
+
 const logger = pino({
-  // Default to 'debug' in development and 'info' in production
-  level: process.env.AXAR_LOG_LEVEL || (isNotProduction ? 'info' : 'info'),
-  transport: isNotProduction
-    ? {
-        target: 'pino-pretty',
-        options: {
-          colorize: true,
-        },
-      }
-    : undefined, // Use default JSON output in production
+  level: process.env.AXAR_LOG_LEVEL || (isNotProduction ? 'debug' : 'info'),
+  transport: getPrettyTransport(),
 });
 
 export default logger;

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,28 +1,27 @@
 import pino from 'pino';
 
-const isNotProduction = process.env.NODE_ENV !== 'production';
+const isProduction = process.env.NODE_ENV === 'production';
+let transport = undefined;
 
-// Check if pino-pretty is available
-const getPrettyTransport = () => {
-  if (!isNotProduction) return undefined;
-
+// Only attempt to use pino-pretty in non-production
+if (!isProduction) {
   try {
-    require.resolve('pino-pretty');
-    return {
+    // If pino-pretty is available, it will be loaded
+    require('pino-pretty');
+    transport = {
       target: 'pino-pretty',
-      options: {
-        colorize: true,
-      },
+      options: { colorize: true },
     };
   } catch (e) {
-    // Silently fallback to default transport if pino-pretty is not available
-    return undefined;
+    console.debug(
+      'pino-pretty not available, falling back to default transport',
+    );
   }
-};
+}
 
 const logger = pino({
-  level: process.env.AXAR_LOG_LEVEL || (isNotProduction ? 'debug' : 'info'),
-  transport: getPrettyTransport(),
+  level: process.env.AXAR_LOG_LEVEL || 'info',
+  transport,
 });
 
 export default logger;

--- a/test/unit/common/logger.test.ts
+++ b/test/unit/common/logger.test.ts
@@ -1,34 +1,34 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 // Mock pino to control transport configuration
-jest.mock('pino', () => {
-  return jest.fn((config) => ({
-    level: config.level,
-    transport: config.transport
-  }));
-});
+const pinoMock = jest.fn((config) => ({
+  level: config.level,
+  transport: config.transport,
+}));
+
+jest.mock('pino', () => pinoMock);
+
+// Mock pino-pretty for successful case
+jest.mock('pino-pretty', () => ({}), { virtual: true });
 
 describe('Logger', () => {
   const originalEnv = process.env;
+  const originalConsoleDebug = console.debug;
 
   beforeEach(() => {
     jest.resetModules();
     process.env = { ...originalEnv };
+    pinoMock.mockClear();
+    console.debug = jest.fn();
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    console.debug = originalConsoleDebug;
     jest.clearAllMocks();
   });
 
-  it('should use info level by default in development', () => {
-    process.env.NODE_ENV = 'development';
-    const logger = require('../../../src/common/logger').default;
-    expect(logger.level).toBe('info');
-  });
-
-  it('should use info level by default in production', () => {
-    process.env.NODE_ENV = 'production';
+  it('should use info level by default', () => {
     const logger = require('../../../src/common/logger').default;
     expect(logger.level).toBe('info');
   });
@@ -39,26 +39,38 @@ describe('Logger', () => {
     expect(logger.level).toBe('debug');
   });
 
-  it('should use pino-pretty transport in development', () => {
+  it('should use pino-pretty transport in non-production', () => {
     process.env.NODE_ENV = 'development';
     const logger = require('../../../src/common/logger').default;
-    expect(logger.transport).toBeDefined();
-    expect(logger.transport.target).toBe('pino-pretty');
-    expect(logger.transport.options).toEqual({
-      colorize: true,
+    expect(logger.transport).toEqual({
+      target: 'pino-pretty',
+      options: { colorize: true },
     });
   });
 
-  it('should use default JSON transport in production', () => {
+  it('should not use pino-pretty transport in production', () => {
     process.env.NODE_ENV = 'production';
     const logger = require('../../../src/common/logger').default;
     expect(logger.transport).toBeUndefined();
   });
 
-  it('should handle test environment as non-production', () => {
-    process.env.NODE_ENV = 'test';
+  it('should fallback to default transport when pino-pretty is not available', () => {
+    // First unmock pino-pretty
+    jest.unmock('pino-pretty');
+    // Then mock it to throw
+    jest.mock(
+      'pino-pretty',
+      () => {
+        throw new Error('Cannot find module "pino-pretty"');
+      },
+      { virtual: true },
+    );
+
+    process.env.NODE_ENV = 'development';
     const logger = require('../../../src/common/logger').default;
-    expect(logger.transport).toBeDefined();
-    expect(logger.transport.target).toBe('pino-pretty');
+    expect(logger.transport).toBeUndefined();
+    expect(console.debug).toHaveBeenCalledWith(
+      'pino-pretty not available, falling back to default transport',
+    );
   });
 });


### PR DESCRIPTION
- Move pino-pretty from devDependencies to optional peerDependencies
- Add getPrettyTransport helper to safely check for pino-pretty
- Improve logger configuration with graceful fallback
- Set default log level to 'debug' in development
- Update package-lock.json